### PR TITLE
Fixed-Gruntfile.js must only in root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Build your project using Grunt from Atom.
 ## How to use
  * Set a path to your local `grunt-cli` in the settings
  (may not be necessary).
- * Open a project that has a `Gruntfile.js` in the root.
+ * Set the relative path of Gruntfile in the settings
+ if the Gruntfile.coffe(js) is NOT in the root directory of your project workspace.
+>For Exmaple, if Gruntfile.coffee(or .js) is in your project/workspace/path/build,
+then type `build/` here.
+ * Open a project that has a `Gruntfile.js` or `Gruntfile.coffee` in the root
  * Open the task list (`ctrl-alt-g`) and choose a task to run, or input a new one.
  * The output from the grunt task will be shown in bottom toolbar. Toggle
  the log with `ctrl-alt-t`, toggle the entire toolbar with
@@ -28,10 +32,6 @@ Install Grunt Runner package using the command line
 Or install it from the Atom Package Manager.
 
 ## Known issues
-
- * The Gruntfile must be in the root of your project directory to successfully
- get the available tasks. Additionally, all `grunt` commands will be called
- in the root directory.
 
  * Tasks added to a Gruntfile will not be automatically added until the project
  is reloaded or the page gets refreshed. They will still be callable from from

--- a/lib/grunt-runner-view.coffee
+++ b/lib/grunt-runner-view.coffee
@@ -9,12 +9,14 @@ Also launches an Atom BufferedProcess to run grunt when needed.
 
 {View, BufferedProcess, Task, $} = require 'atom'
 ListView = require './task-list-view'
+path = require 'path'
 
 module.exports = class ResultsView extends View
 
     path: null,
     process: null,
     taskList: null,
+    gruntfileRelativePath:null
 
     # html layout
     @content: ->
@@ -34,7 +36,9 @@ module.exports = class ResultsView extends View
     # gets the projects current path and launches a task
     # to parse the projects gruntfile if it exists
     initialize:(state = {}) ->
-        @path = atom.project.getPath();
+        @gruntfileRelativePath = atom.config.get('grunt-runner').gruntfileRelativePath unless @gruntfileRelativePath
+        @path = if @gruntfileRelativePath then path.join(atom.project.getPath(),@gruntfileRelativePath) else atom.project.getPath()
+
         @taskList = new ListView @startProcess.bind(@), state.taskList
         @on 'mousedown', '.grunt-runner-resizer-handle', (e) => @resizeStarted(e)
 

--- a/lib/grunt-runner.coffee
+++ b/lib/grunt-runner.coffee
@@ -10,6 +10,7 @@ window.View = require './grunt-runner-view.coffee'
 module.exports =
     configDefaults:
         gruntPaths: []
+        gruntfileRelativePath: ''
 
     originalPath: ''
 
@@ -17,6 +18,7 @@ module.exports =
     activate:(state = {}) ->
         @originalPath = process.env.PATH
         atom.config.observe 'grunt-runner.gruntPaths', @updateSettings.bind @
+        atom.config.observe 'grunt-runner.gruntfileRelativePath', @updateSettings.bind @
 
         @view = new View(state)
         atom.workspaceView.command 'grunt-runner:stop', @view.stopProcess.bind @view
@@ -30,6 +32,10 @@ module.exports =
         gruntPaths = atom.config.get('grunt-runner').gruntPaths
         gruntPaths = if Array.isArray gruntPaths then gruntPaths else []
         process.env.PATH = @originalPath + (if gruntPaths.length > 0 then ':' else '') + gruntPaths.join ':'
+
+        # updates the view.path to include Relative Path from current workspace
+        gruntfileRelativePath = atom.config.get('grunt-runner').gruntfileRelativePath
+        @view?.gruntfileRelativePath = if gruntfileRelativePath then gruntfileRelativePath else ''
 
     # returns a JSON object representing the packages state
     serialize: ->

--- a/lib/parse-config-task.coffee
+++ b/lib/parse-config-task.coffee
@@ -6,11 +6,17 @@ installation to parse a projects Gruntfile
 ###
 
 grunt = require 'grunt'
+path = require 'path'
 
 # attempts to load the gruntfile
 module.exports = (path) ->
     try
-        require(path)(grunt)
+        #this does not work while the gruntfile is not in the workspace root directory
+        # require(path)(grunt)
+        grunt = require(path.join path, "/node_modules/grunt")
+        gruntfile=findup 'Gruntfile.{js,coffee}', {cwd: path,nocase: true}
+        grunt.option 'gruntfile',gruntfile
+        grunt.task.init [], {}
     catch e
         error = e.code
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "grunt": "~0.4.2"
+    "grunt": "~0.4.2",
+    "findup-sync": "~0.1.3",
+    "path": "~0.4.9"
   }
 }


### PR DESCRIPTION
Fixed Known Issue #1- The Gruntfile must be in the root of your project
directory to successfully get the available tasks. Additionally, all
grunt commands will be called in the root directory.
Now, the Gruntfile.coffee (or Gruntfile.js) can be in a sub-directory
of the root directory. And all grunt will run in the Gruntfile
directory.
