### PR TITLE
Add support to list all tasks in a multi task.

### DIFF
--- a/lib/parse-config-task.coffee
+++ b/lib/parse-config-task.coffee
@@ -27,4 +27,12 @@ module.exports = (gruntfilePath) ->
         error = e.code
         return {error: "Error parsing Gruntfile. " + e.message, path: gruntfilePath}
 
-    return {tasks: Object.keys grunt.task._tasks}
+    # get all tasks and subtasks
+    tasks = []
+    for own task of grunt.task._tasks
+        raws = Object.keys grunt.config.get(task) or {}
+        subs = (sub for sub in raws when sub not in ["files", "options", "globals"])
+        tasks.push String task
+        tasks.push "#{task}:#{sub}" for sub in subs if subs.length > 1
+
+    return {tasks: tasks}


### PR DESCRIPTION
Currently for multi tasks, all sub tasks are run. This request gives the option to select a subtask in addition to the whole multi task. See #1. This is my first shot at Coffeescript, so feel free to correct where necessary.

An example task that has the ability to define multiple sub tasks is [grunt-contrib-requirejs](https://github.com/gruntjs/grunt-contrib-requirejs). An example Gruntfile could could be:

```javascript
module.exports = function(grunt) {
    "use strict";

    // Build configuration
    grunt.initConfig({
        pkg: grunt.file.readJSON("package.json"),
        requirejs: {
            compile: {
                options: {
                    baseUrl: "js",
                    name: "main",
                    mainConfigFile: "js/app/js/main.js",
                    optimizeAllPluginResources: true,
                    paths: {
                        main: "app/js/main"
                    },
                    out: "js/dist/base.min.js"
                }
            },
            compileRetail: {
                options: {
                    baseUrl: "js",
                    name: "main",
                    mainConfigFile: "js/app/js/main-retail.js",
                    optimizeAllPluginResources: true,
                    paths: {
                        main: "app/js/main-retail"
                    },
                    out: "js/dist/retail.min.js"
                }
            }
        },
        jshint: {
            options: {
                jshintrc: true
            },
            all: ["js/app/js/**/*.js"]
        },
        jsdoc: {
            dist: {
                src: ["js/app/js/**/*.js", "README.md"],
                dest: "js/docs"
            }
        }
    });

    // Run the requirejs optimizer/build
    grunt.loadNpmTasks("grunt-contrib-requirejs");

    // Run jshint
    grunt.loadNpmTasks("grunt-contrib-jshint");

    // Build the documentation
    grunt.loadNpmTasks("grunt-jsdoc");

    // Register the default build task
    grunt.registerTask("default", ["jshint", "requirejs", "jsdoc"]);
};
```