### PR TITLE
Fix for Gruntfile.js path

### DIFF
--- a/lib/grunt-runner.coffee
+++ b/lib/grunt-runner.coffee
@@ -16,7 +16,7 @@ module.exports =
             default: []
         gruntfilePaths:
             type: 'array'
-            default: ['/Gruntfile.js', '/gruntfile.js']
+            default: ['/Gruntfile', '/gruntfile']
     view: null
 
     # creates grunt-runner view and starts listening for commands

--- a/lib/grunt-runner.coffee
+++ b/lib/grunt-runner.coffee
@@ -16,7 +16,7 @@ module.exports =
             default: []
         gruntfilePaths:
             type: 'array'
-            default: [' /Gruntfile', '/gruntfile']
+            default: ['/Gruntfile.js', '/gruntfile.js']
     view: null
 
     # creates grunt-runner view and starts listening for commands


### PR DESCRIPTION
There was an space that brokes the search path, and append .js extensión on the options.

this solves #73 